### PR TITLE
Markdown editor

### DIFF
--- a/maidnomadweb/apps/core/templates/markdown.html
+++ b/maidnomadweb/apps/core/templates/markdown.html
@@ -1,0 +1,25 @@
+{#
+    オリジナルの django-mdeditor ではできない editor.md のオプションを設定する
+
+    オプションは以下を参照
+    https://github.com/pandao/editor.md
+#}
+<script type="text/javascript">
+    (function() {
+        // オリジナルを退避
+        var org_editormd = editormd;
+
+        // 関数を上書き
+        window.editormd = function(id, options) {
+            // オリジナルではタブがハードタブなのでソフトタブに変更する
+            options.indentWithTabs = false;
+            options.indentUnit = 2;
+            options.indentUnit = 2;
+            options.imageUpload = false;
+            // オリジナルを呼ぶ
+            return org_editormd(id, options);
+        };
+    })();
+</script>
+{# オリジナルテンプレート呼び出し #}
+{% extends "markdown.html" %}

--- a/maidnomadweb/apps/maidlist/models.py
+++ b/maidnomadweb/apps/maidlist/models.py
@@ -4,14 +4,14 @@ from django.db.models.fields import (
     CharField,
     DateTimeField,
     IntegerField,
-    TextField,
 )
+from mdeditor.fields import MDTextField
 
 
 class MaidProfile(Model):
     code = CharField("英語表記", max_length=50, unique=True)
     name = CharField("名前", max_length=128)
-    content = TextField("自己紹介", blank=True)
+    content = MDTextField("自己紹介", blank=True)
     thumbnail_image = ImageField(
         "サムネイル画像", upload_to="maidlist_thumbnail/", null=True, blank=True
     )

--- a/maidnomadweb/maidnomadweb/settings.py
+++ b/maidnomadweb/maidnomadweb/settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = [
     "admin_ordering",
     "reversion",
     "import_export",
+    "mdeditor",
     "apps.core",
     "apps.staticpage",
     "apps.maidlist",
@@ -143,6 +144,8 @@ USE_L10N = True
 
 USE_TZ = True
 
+X_FRAME_OPTIONS = "SAMEORIGIN"
+
 
 MEDIA_ROOT = BASE_DIR / "media"
 MEDIA_URL = "/media/"
@@ -173,6 +176,24 @@ if AWS_S3_ACCESS_KEY_ID and AWS_S3_SECRET_ACCESS_KEY:
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+
+# MDEDITOR
+
+MDEDITOR_CONFIGS = {
+    "default": {
+        "language": "en",
+        "toolbar": [
+            # fmt: off
+            "undo", "redo", "|",
+            "bold", "del", "italic", "quote", "uppercase", "lowercase", "|",
+            "list-ul", "list-ol", "hr", "|",
+            "link", "code", "table",
+            "|",
+            "help", "info",
+            "||", "preview", "watch"
+        ],
+    }
+}
 
 # Logging
 LOGGING: dict[str, Any] = {

--- a/maidnomadweb/maidnomadweb/settings.py
+++ b/maidnomadweb/maidnomadweb/settings.py
@@ -62,10 +62,10 @@ INSTALLED_APPS = [
     "admin_ordering",
     "reversion",
     "import_export",
-    "mdeditor",
     "apps.core",
     "apps.staticpage",
     "apps.maidlist",
+    "mdeditor",
 ]
 
 MIDDLEWARE = [
@@ -192,6 +192,9 @@ MDEDITOR_CONFIGS = {
             "help", "info",
             "||", "preview", "watch"
         ],
+        "upload_image_formats": [],
+        "lineWrapping": True,
+        "watch": False,
     }
 }
 

--- a/maidnomadweb/maidnomadweb/urls.py
+++ b/maidnomadweb/maidnomadweb/urls.py
@@ -6,6 +6,7 @@ from django.urls import include, path
 
 urlpatterns = [
     path("__django_admin/", admin.site.urls),
+    path("mdeditor/", include("mdeditor.urls")),
     path(
         "parts/menu_only",
         lambda request: render(request, "menu.html"),

--- a/requirements.lock
+++ b/requirements.lock
@@ -14,6 +14,7 @@ Django==3.2.9
 django-admin-ordering==0.14.1
 django-import-export==2.6.1
 django-js-asset==1.2.2
+django-mdeditor==0.1.18
 django-reversion==4.0.1
 django-storages==1.12.3
 et-xmlfile==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ boto3
 markdown
 bleach
 bleach_allowlist
+django-mdeditor


### PR DESCRIPTION
## 対象チケット

- なし

## 変更点

メイドさんリストをMarkDownエディターで編集できるようにした

- 追加: django-mdeditor プラグインを導入
- 変更: django-mdeditor 内部で呼んでいる editor.md の呼び出しオプションを変更

## レビュー観点

- コード観点

## セルフチェック

- [ ] セルフレビューをしたか
