### PR TITLE
GoogleがTopPageにもパンくずいれろというので入れた

### DIFF
--- a/maidnomadweb/apps/staticpage/views.py
+++ b/maidnomadweb/apps/staticpage/views.py
@@ -20,10 +20,8 @@ def staticpage(name: str):
     def inner(request: HttpRequest) -> HttpResponse:
         staticpage = STATICPAGES[name]
 
-        breadcrumbs = None
-        if "parent" in staticpage:
-            breadcrumbs = _breadcrumbs(name)
-            del breadcrumbs[-1]["url"]
+        breadcrumbs = _breadcrumbs(name)
+        del breadcrumbs[-1]["url"]
 
         title = None
         if name != "top":


### PR DESCRIPTION
## 対象チケット

- なし
Google Search Console 曰く

```
項目「itemListElement」がありません
```

## 変更点

以下から不要なものを消し、必要な説明を補う

- 削除: TopPageの場合はパンくずの出力を抑制するif文を削除

## レビュー観点

以下から不要なものを消し、必要な説明を補う

- コード観点

## セルフチェック

- [x] セルフレビューをしたか
