### PR TITLE
stafflistもmarkdownにはnl2brを入れた方が直感的なので追加

### DIFF
--- a/maidnomadweb/apps/stafflist/views.py
+++ b/maidnomadweb/apps/stafflist/views.py
@@ -168,7 +168,7 @@ class StaffProfileViewSet(metaclass=ABCMeta):
         エスケープせずに出力しても安全です。
         """
 
-        content_html = markdown(content)
+        content_html = markdown(content, extensions=["nl2br"])
         # unsafe でレンダリングするのでHTMLをサニタイズする
         content_html_safe = bleach.clean(content_html, markdown_tags)
         return content_html_safe


### PR DESCRIPTION
## 対象チケット

- なし

DjangoAdminでのエディタでは改行するとプレビュー画面に改行が反映されるが、実際のページでは改行されていなかったので、プレビューと同じように改行されるようにした。

## 変更点

以下から不要なものを消し、必要な説明を補う

- 変更: メイドさん自己紹介、オーガナイザー紹介ページでMarkdown内で改行したら反映されるようにした

## レビュー観点

以下から不要なものを消し、必要な説明を補う

- 機能観点: 不要
- コード観点: 不要

## セルフチェック

- [x] セルフレビューをしたか
